### PR TITLE
LICENSE: respect MIT by rolling back license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Achmad Mahardi
+Copyright (c) 2015 Derek Stavis
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -37,10 +37,11 @@ refresh
 
 # License
 
-[MIT][mit] © [Achmad Mahardi][author] et [al][contributors]
+[MIT][mit] © [Derek Stavis][author], ported to gvm by [Achmad Mahardi][maman] et [al][contributors]
 
 
 [mit]:            http://opensource.org/licenses/MIT
-[author]:         http://github.com/maman
+[author]:         http://github.com/derekstavis
+[maman]:          http://github.com/maman
 [omf-link]:       https://www.github.com/oh-my-fish/oh-my-fish
 [contributors]:   https://github.com/maman/plugin-gvm/graphs/contributors


### PR DESCRIPTION
MIT doesn't allow you to change the LICENSE information.

I'm rolling back the LICENSE file and adjusting the attribution on README seeking to respect the original licensing.